### PR TITLE
Altered styles and added some props

### DIFF
--- a/src-docs/src/views/drag_and_drop/drag_and_drop.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop.js
@@ -25,19 +25,17 @@ export default () => {
   };
   return (
     <EuiDragDropContext onDragEnd={onDragEnd}>
-      <EuiPanel paddingSize="none">
-        <EuiDroppable droppableId="DROPPABLE_AREA" style={{ padding: '10px' }}>
-          {list.map(({ content, id }, idx) => (
-            <EuiDraggable key={id} index={idx} draggableId={id}>
-              {(provided, state) => (
-                <EuiPanel>
-                  {content}{state.isDragging && ' ✨'}
-                </EuiPanel>
-              )}
-            </EuiDraggable>
-          ))}
-        </EuiDroppable>
-      </EuiPanel>
+      <EuiDroppable droppableId="DROPPABLE_AREA" spacing="m" withPanel>
+        {list.map(({ content, id }, idx) => (
+          <EuiDraggable spacing="m" key={id} index={idx} draggableId={id}>
+            {(provided, state) => (
+              <EuiPanel hasShadow={state.isDragging}>
+                {content}{state.isDragging && ' ✨'}
+              </EuiPanel>
+            )}
+          </EuiDraggable>
+        ))}
+      </EuiDroppable>
     </EuiDragDropContext>
   );
 };

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_clone.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_clone.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {
+  EuiButtonIcon,
   EuiDragDropContext,
   EuiFlexGroup,
   EuiFlexItem,
@@ -54,37 +55,40 @@ export default () => {
     <EuiDragDropContext onDragEnd={onDragEnd}>
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none" grow={false}>
-            <EuiDroppable droppableId="DROPPABLE_AREA_COPY_1" cloneDraggables={true} style={{ padding: '10px' }}>
-              {list1.map(({ content, id }, idx) => (
-                <EuiDraggable key={id} index={idx} draggableId={id}>
-                  <EuiPanel>
-                    {content}
-                  </EuiPanel>
-                </EuiDraggable>
-              ))}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_COPY_1" cloneDraggables={true}>
+            {list1.map(({ content, id }, idx) => (
+              <EuiDraggable key={id} index={idx} draggableId={id} spacing="l">
+                <EuiPanel>
+                  {content}
+                </EuiPanel>
+              </EuiDraggable>
+            ))}
+          </EuiDroppable>
+
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none">
-            <EuiDroppable droppableId="DROPPABLE_AREA_COPY_2" style={{ padding: '10px', height: '100%' }}>
-              {list2.length ?
-                (
-                  list2.map(({ content, id }, idx) => (
-                    <EuiDraggable key={id} index={idx} draggableId={id}>
-                      <EuiPanel>
-                        {content}
-                      </EuiPanel>
-                    </EuiDraggable>
-                  ))
-                ) : (
-                  <EuiFlexGroup alignItems="center" justifyContent="spaceAround" gutterSize="none" style={{ height: '100%' }}>
-                    <EuiFlexItem grow={false}>Drop Items Here</EuiFlexItem>
-                  </EuiFlexGroup>
-                )}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_COPY_2" withPanel spacing="l" grow>
+            {list2.length ?
+              (
+                list2.map(({ content, id }, idx) => (
+                  <EuiDraggable key={id} index={idx} draggableId={id} spacing="l">
+                    <EuiPanel>
+                      <EuiFlexGroup gutterSize="none" alignItems="center">
+                        <EuiFlexItem>{content}</EuiFlexItem>
+                        <EuiFlexItem grow={false}><EuiButtonIcon iconType="cross" /></EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiPanel>
+                  </EuiDraggable>
+                ))
+              ) : (
+                <EuiFlexGroup alignItems="center" justifyContent="spaceAround" gutterSize="none" style={{ height: '100%' }}>
+                  <EuiFlexItem grow={false}>Drop Items Here</EuiFlexItem>
+                </EuiFlexGroup>
+              )}
+          </EuiDroppable>
+
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiDragDropContext>

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_complex.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_complex.js
@@ -3,7 +3,7 @@ import {
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
-  EuiIcon,
+  EuiButtonIcon,
   EuiPanel
 } from '../../../../src/components';
 
@@ -45,35 +45,38 @@ export default () => {
   };
   return (
     <EuiDragDropContext onDragEnd={onDragEnd}>
-      <EuiPanel paddingSize="none">
-        <EuiDroppable
-          droppableId="COMPLEX_DROPPABLE_PARENT"
-          type="MACRO"
-          direction="horizontal"
-          style={{ padding: '10px', display: 'flex' }}
-        >
-          {list.map((did, didx) => (
-            <EuiDraggable key={did} index={didx} draggableId={`COMPLEX_DRAGGABLE_${did}`} style={{ width: '50%', padding: '0 5px' }}>
-              {(provided) => (
-                <EuiPanel paddingSize="s">
-                  <div {...provided.dragHandleProps}>
-                    <EuiIcon type="grab" />
-                  </div>
-                  <EuiDroppable droppableId={`COMPLEX_DROPPABLE_AREA_${did}`} type="MICRO" style={{ padding: '5px' }}>
-                    {lists[`COMPLEX_DROPPABLE_AREA_${did}`].map(({ content, id }, idx) => (
-                      <EuiDraggable key={id} index={idx} draggableId={id}>
-                        <EuiPanel>
-                          {content}
-                        </EuiPanel>
-                      </EuiDraggable>
-                    ))}
-                  </EuiDroppable>
-                </EuiPanel>
-              )}
-            </EuiDraggable>
-          ))}
-        </EuiDroppable>
-      </EuiPanel>
+
+      <EuiDroppable
+        droppableId="COMPLEX_DROPPABLE_PARENT"
+        type="MACRO"
+        direction="horizontal"
+        withPanel
+        spacing="l"
+        style={{ display: 'flex' }}
+      >
+        {list.map((did, didx) => (
+          <EuiDraggable key={did} index={didx} draggableId={`COMPLEX_DRAGGABLE_${did}`} spacing="l" style={{ flex: '1 0 50%' }}>
+            {(provided) => (
+              <EuiPanel paddingSize="s">
+                <EuiButtonIcon
+                  iconType="grab"
+                  {...provided.dragHandleProps}
+                />
+                <EuiDroppable droppableId={`COMPLEX_DROPPABLE_AREA_${did}`} type="MICRO" spacing="m" style={{ flex: '1 0 50%' }}>
+                  {lists[`COMPLEX_DROPPABLE_AREA_${did}`].map(({ content, id }, idx) => (
+                    <EuiDraggable key={id} index={idx} draggableId={id} spacing="m">
+                      <EuiPanel>
+                        {content}
+                      </EuiPanel>
+                    </EuiDraggable>
+                  ))}
+                </EuiDroppable>
+              </EuiPanel>
+            )}
+          </EuiDraggable>
+        ))}
+      </EuiDroppable>
+
     </EuiDragDropContext>
   );
 };

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
@@ -3,10 +3,9 @@ import {
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiIcon,
-  EuiPanel
+  EuiListGroup,
+  EuiListGroupItem,
 } from '../../../../src/components';
 
 import { reorder } from '../../../../src/components/drag_and_drop';
@@ -28,29 +27,22 @@ export default () => {
   };
   return (
     <EuiDragDropContext onDragEnd={onDragEnd}>
-      <EuiPanel paddingSize="none">
-        {/* Do we want to add padding prop similar to EuiPanel? */}
-        <EuiDroppable droppableId="CUSTOM_HANDLE_DROPPABLE_AREA" style={{ padding: '10px' }}>
+      <EuiListGroup bordered flush>
+        <EuiDroppable droppableId="CUSTOM_HANDLE_DROPPABLE_AREA">
           {list.map(({ content, id }, idx) => (
             <EuiDraggable key={id} index={idx} draggableId={id} customDragHandle={true}>
               {(provided) => (
-                <EuiPanel className="custom" paddingSize="m">
-                  <EuiFlexGroup>
-                    <EuiFlexItem grow={false}>
-                      <div {...provided.dragHandleProps}>
-                        <EuiIcon type="grab" />
-                      </div>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      {content}
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiPanel>
+
+                <EuiListGroupItem
+                  icon={<div {...provided.dragHandleProps}><EuiIcon type="grab" /></div>}
+                  label={content}
+                />
+
               )}
             </EuiDraggable>
           ))}
         </EuiDroppable>
-      </EuiPanel>
+      </EuiListGroup>
     </EuiDragDropContext>
   );
 };

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_move_lists.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_move_lists.js
@@ -50,34 +50,34 @@ export default () => {
     <EuiDragDropContext onDragEnd={onDragEnd}>
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none" grow={false}>
-            <EuiDroppable droppableId="DROPPABLE_AREA_1" style={{ padding: '10px' }}>
-              {list1.map(({ content, id }, idx) => (
-                <EuiDraggable key={id} index={idx} draggableId={id}>
-                  {(provided, state) => (
-                    <EuiPanel>
-                      {content}{state.isDragging && ' ✨'}
-                    </EuiPanel>
-                  )}
-                </EuiDraggable>
-              ))}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_1">
+            {list1.map(({ content, id }, idx) => (
+              <EuiDraggable spacing="m" key={id} index={idx} draggableId={id}>
+                {(provided, state) => (
+                  <EuiPanel>
+                    {content}{state.isDragging && ' ✨'}
+                  </EuiPanel>
+                )}
+              </EuiDraggable>
+            ))}
+          </EuiDroppable>
+
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none" grow={false}>
-            <EuiDroppable droppableId="DROPPABLE_AREA_2" style={{ padding: '10px' }}>
-              {list2.map(({ content, id }, idx) => (
-                <EuiDraggable key={id} index={idx} draggableId={id}>
-                  {(provided, state) => (
-                    <EuiPanel>
-                      {content}{state.isDragging && ' ✨'}
-                    </EuiPanel>
-                  )}
-                </EuiDraggable>
-              ))}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_2">
+            {list2.map(({ content, id }, idx) => (
+              <EuiDraggable spacing="m" key={id} index={idx} draggableId={id}>
+                {(provided, state) => (
+                  <EuiPanel>
+                    {content}{state.isDragging && ' ✨'}
+                  </EuiPanel>
+                )}
+              </EuiDraggable>
+            ))}
+          </EuiDroppable>
+
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiDragDropContext>

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_types.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_types.js
@@ -51,49 +51,49 @@ export default () => {
     <EuiDragDropContext onDragEnd={onDragEnd}>
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none" grow={false}>
-            <EuiDroppable droppableId="DROPPABLE_AREA_TYPE_1" type="TYPE_ONE" style={{ padding: '10px' }}>
-              {list1.map(({ content, id }, idx) => (
-                <EuiDraggable key={id} index={idx} draggableId={id}>
-                  {(provided, state) => (
-                    <EuiPanel>
-                      {content}{state.isDragging && ' ✨'}
-                    </EuiPanel>
-                  )}
-                </EuiDraggable>
-              ))}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_TYPE_1" type="TYPE_ONE" spacing="m" withPanel grow={false}>
+            {list1.map(({ content, id }, idx) => (
+              <EuiDraggable key={id} index={idx} draggableId={id} spacing="m">
+                {(provided, state) => (
+                  <EuiPanel hasShadow={state.isDragging}>
+                    {content}{state.isDragging && ' ✨'}
+                  </EuiPanel>
+                )}
+              </EuiDraggable>
+            ))}
+          </EuiDroppable>
+
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none" grow={false}>
-            <EuiDroppable droppableId="DROPPABLE_AREA_TYPE_2" type="TYPE_ONE" style={{ padding: '10px' }}>
-              {list2.map(({ content, id }, idx) => (
-                <EuiDraggable key={id} index={idx} draggableId={id}>
-                  {(provided, state) => (
-                    <EuiPanel>
-                      {content}{state.isDragging && ' ✨'}
-                    </EuiPanel>
-                  )}
-                </EuiDraggable>
-              ))}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_TYPE_2" type="TYPE_ONE" spacing="m" withPanel grow={false}>
+            {list2.map(({ content, id }, idx) => (
+              <EuiDraggable key={id} index={idx} draggableId={id} spacing="m">
+                {(provided, state) => (
+                  <EuiPanel hasShadow={state.isDragging}>
+                    {content}{state.isDragging && ' ✨'}
+                  </EuiPanel>
+                )}
+              </EuiDraggable>
+            ))}
+          </EuiDroppable>
+
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiPanel paddingSize="none" grow={false}>
-            <EuiDroppable droppableId="DROPPABLE_AREA_TYPE_3" type="TYPE_TWO" style={{ padding: '10px' }}>
-              {list3.map(({ content, id }, idx) => (
-                <EuiDraggable key={id} index={idx} draggableId={id}>
-                  {(provided, state) => (
-                    <EuiPanel>
-                      {content}{state.isDragging && ' ✨'}
-                    </EuiPanel>
-                  )}
-                </EuiDraggable>
-              ))}
-            </EuiDroppable>
-          </EuiPanel>
+
+          <EuiDroppable droppableId="DROPPABLE_AREA_TYPE_3" type="TYPE_TWO" spacing="m" withPanel grow={true}>
+            {list3.map(({ content, id }, idx) => (
+              <EuiDraggable key={id} index={idx} draggableId={id} spacing="m">
+                {(provided, state) => (
+                  <EuiPanel hasShadow={state.isDragging}>
+                    {content}{state.isDragging && ' ✨'}
+                  </EuiPanel>
+                )}
+              </EuiDraggable>
+            ))}
+          </EuiDroppable>
+
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiDragDropContext>

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiDraggable can be given ReactElement children 1`] = `
 <div
-  class="euiDroppable"
+  class="euiDroppable euiDroppable--noGrow"
   data-react-beautiful-dnd-droppable="1"
   data-test-subj="droppable"
 >
@@ -29,7 +29,7 @@ exports[`EuiDraggable can be given ReactElement children 1`] = `
 
 exports[`EuiDraggable is rendered 1`] = `
 <div
-  class="euiDroppable"
+  class="euiDroppable euiDroppable--noGrow"
   data-react-beautiful-dnd-droppable="0"
   data-test-subj="droppable"
 >

--- a/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiDroppable can be given ReactElement children 1`] = `
 <div
-  class="euiDroppable"
+  class="euiDroppable euiDroppable--noGrow"
   data-react-beautiful-dnd-droppable="2"
   data-test-subj="droppable"
 >
@@ -15,7 +15,7 @@ exports[`EuiDroppable can be given ReactElement children 1`] = `
 
 exports[`EuiDroppable is rendered 1`] = `
 <div
-  class="euiDroppable"
+  class="euiDroppable euiDroppable--noGrow"
   data-react-beautiful-dnd-droppable="1"
   data-test-subj="droppable"
 >

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -1,7 +1,6 @@
-.euiDraggable {
-  $euiDraggableFocusColor: lighten(desaturate($euiColorPrimary, 40%), 40%);
-  padding: 5px 0;
+// sass-lint:disable no-empty-rulesets
 
+.euiDraggable {
   &.euiDraggable--isDragging {
     // Overriding inline styles on JS-inserted HTML elements
     z-index: $euiZLevel9 !important; // sass-lint:disable-line no-important
@@ -13,26 +12,31 @@
   }
 
   &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle] {
-    border: 1px solid transparent;
+    // What was the reason for the transparent border?
+    // border: 1px solid transparent;
   }
 
   &:focus > .euiDraggable__item,
   &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle]:focus {
-    border: 1px solid $euiDraggableFocusColor;
+    @include euiFocusRing;
   }
 
   .euiDraggable__item {
-    &:hover {
-      @include euiSlightShadowHover;
-    }
-
     &.euiDraggable__item--isDisabled {
       cursor: not-allowed;
     }
 
     &.euiDraggable__item--isDragging {
-      @include euiBottomShadow;
-      border: 1px solid $euiDraggableFocusColor;
+      // Commenting this out for now,
+      // I'm thinking about adding an optional prop to auto-add these styles versus always having them
+      // @include euiBottomShadow;
+      // @include euiFocusRing;
     }
+  }
+}
+
+@each $size, $spacing in $euiDragAndDropSpacing {
+  .euiDraggable--#{$size} {
+    padding: $spacing;
   }
 }

--- a/src/components/drag_and_drop/_droppable.scss
+++ b/src/components/drag_and_drop/_droppable.scss
@@ -1,3 +1,5 @@
+@import '../panel/mixins';
+
 .euiDroppable {
   $euiDroppableColor: $euiColorSecondary;
   transition: background-color $euiAnimSpeedExtraSlow ease;
@@ -15,5 +17,21 @@
       // Overriding inline styles on JS-inserted HTML elements
       display: none !important; // sass-lint:disable-line no-important
     }
+  }
+}
+
+@include euiPanel('euiDroppable--withPanel');
+
+.euiDroppable--noGrow {
+  flex-grow: 0;
+}
+
+.euiDroppable--grow {
+  flex-grow: 1;
+}
+
+@each $size, $spacing in $euiDragAndDropSpacing {
+  .euiDroppable--#{$size} {
+    padding: $spacing;
   }
 }

--- a/src/components/drag_and_drop/_index.scss
+++ b/src/components/drag_and_drop/_index.scss
@@ -1,2 +1,3 @@
+@import 'variables';
 @import 'draggable';
 @import 'droppable';

--- a/src/components/drag_and_drop/_variables.scss
+++ b/src/components/drag_and_drop/_variables.scss
@@ -1,0 +1,5 @@
+$euiDragAndDropSpacing: (
+  s: ($euiSizeXS / 2),
+  m: ($euiSizeS / 2),
+  l: ($euiSize / 2),
+);

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -8,8 +8,18 @@ import React, {
 } from 'react';
 import { Draggable, DraggableProps } from 'react-beautiful-dnd';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps, Omit, keysOf } from '../common';
 import { EuiDroppableContext } from './droppable';
+
+const spacingToClassNameMap = {
+  none: null,
+  s: 'euiDraggable--s',
+  m: 'euiDraggable--m',
+  l: 'euiDraggable--l',
+};
+
+export const SPACING = keysOf(spacingToClassNameMap);
+export type EuiDraggableSpacing = keyof typeof spacingToClassNameMap;
 
 export interface EuiDraggableProps
   extends CommonProps,
@@ -17,6 +27,7 @@ export interface EuiDraggableProps
   children: ReactElement | DraggableProps['children'];
   className?: string;
   customDragHandle?: boolean;
+  spacing?: EuiDraggableSpacing;
   style?: CSSProperties;
 }
 
@@ -27,6 +38,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
   index,
   children,
   className,
+  spacing = 'none',
   style,
   ...rest
 }) => {
@@ -42,6 +54,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
             'euiDraggable--hasCustomDragHandle': customDragHandle,
             'euiDraggable--isDragging': snapshot.isDragging,
           },
+          spacingToClassNameMap[spacing],
           className
         );
         const childClasses = classNames('euiDraggable__item', {

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -6,8 +6,18 @@ import React, {
 } from 'react';
 import { Droppable, DroppableProps } from 'react-beautiful-dnd';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps, Omit, keysOf } from '../common';
 import { EuiDragDropContextContext } from './drag_drop_context';
+
+const spacingToClassNameMap = {
+  none: null,
+  s: 'euiDroppable--s',
+  m: 'euiDroppable--m',
+  l: 'euiDroppable--l',
+};
+
+export const SPACING = keysOf(spacingToClassNameMap);
+export type EuiDroppableSpacing = keyof typeof spacingToClassNameMap;
 
 export interface EuiDroppableProps
   extends CommonProps,
@@ -16,6 +26,15 @@ export interface EuiDroppableProps
   className?: string;
   cloneDraggables?: boolean;
   style?: CSSProperties;
+  spacing?: EuiDroppableSpacing;
+  /**
+   * Adds an EuiPanel style to the droppable area
+   */
+  withPanel?: boolean;
+  /**
+   * Allow the panel to flex-grow?
+   */
+  grow?: boolean;
 }
 
 export const EuiDroppableContext = React.createContext({
@@ -29,8 +48,11 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
   children,
   className,
   cloneDraggables = false,
+  spacing = 'none',
   style,
   type = 'EUI_DEFAULT',
+  withPanel = false,
+  grow = false,
   ...rest
 }) => {
   const { isDraggingType } = useContext(EuiDragDropContextContext);
@@ -49,7 +71,11 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
             'euiDroppable--isDisabled': dropIsDisabled,
             'euiDroppable--isDraggingOver': snapshot.isDraggingOver,
             'euiDroppable--isDraggingType': isDraggingType === type,
+            'euiDroppable--withPanel': withPanel,
+            'euiDroppable--grow': grow,
+            'euiDroppable--noGrow': !grow,
           },
+          spacingToClassNameMap[spacing],
           className
         );
         const placeholderClasses = classNames('euiDroppable__placeholder', {


### PR DESCRIPTION
While playing with the default, I've decided that the only part that needs to be automatically styled is the shading of the droppable areas (I'll also look into how users can override later).

<img src="https://d.pr/free/i/Y7ZfkF+" width="50%" />

I also felt that using panels for the droppable areas is such a useful feature that we should build it in, so I'm using the prop `withPanel` to add those panel styles (but not the actual component). I also added a `spacing` prop to both the droppable and draggable components.

<img src="https://d.pr/free/i/uXTIuN+" width="50%" />

In the third (custom handle) example I'm playing with the idea of using completely custom/non Panel components, like the **EuiListGroup** and how that's affected by the draggable.

<img src="https://d.pr/free/i/LonCv5+" width="50%" />

For the **copyable** example, I added an `EuiButtonIcon` to the copied item that we should hook up to some remove function. Also, in agreement with chandler that we should allow removal, and so maybe dragging outside of the droppable area should allow removal (though this should be up to the consumer too).

<img src="https://d.pr/free/i/SliSdT+" width="50%" />

Lastly, in the **complex** example, I changed the custom drag handle here to an `EuiButtonIcon` and it's not working as expected. Is it possible to allow this? I think it would simplify some hover and focus states for the consumer so they don't need to add any.

<img src="https://d.pr/free/i/D4O8ja+" width="50%" />