### PR TITLE
Inverted the mocking approach

### DIFF
--- a/scripts/jest/config.json
+++ b/scripts/jest/config.json
@@ -15,14 +15,14 @@
   ],
   "moduleNameMapper": {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/scripts/jest/mocks/file_mock.js",
-    "\\.(css|less|scss)$": "<rootDir>/scripts/jest/mocks/style_mock.js"
+    "\\.(css|less|scss)$": "<rootDir>/scripts/jest/mocks/style_mock.js",
+    "/icon$": "<rootDir>/scripts/jest/mocks/icon_mock.js"
   },
   "setupFiles": [
     "<rootDir>/scripts/jest/setup/polyfills.js",
     "<rootDir>/scripts/jest/setup/enzyme.js",
     "<rootDir>/scripts/jest/setup/throw_on_console_error.js"
   ],
-  "setupFilesAfterEnv": ["<rootDir>/scripts/jest/setup/mocks.js"],
   "coverageDirectory": "<rootDir>/reports/jest-coverage",
   "coverageReporters": [
     "html"

--- a/scripts/jest/mocks/icon_mock.js
+++ b/scripts/jest/mocks/icon_mock.js
@@ -1,0 +1,1 @@
+export * from '../../../src/components/icon/icon.testenv';

--- a/scripts/jest/setup/mocks.js
+++ b/scripts/jest/setup/mocks.js
@@ -1,6 +1,0 @@
-jest.mock('../../../src/components/icon', () => {
-  const { EuiIcon } = require.requireActual('../../../src/components/icon/icon.testenv');
-  return {
-    EuiIcon
-  };
-});

--- a/src/components/empty_prompt/__snapshots__/empty_prompt.test.tsx.snap
+++ b/src/components/empty_prompt/__snapshots__/empty_prompt.test.tsx.snap
@@ -6,15 +6,9 @@ exports[`EuiEmptyPrompt is rendered 1`] = `
   class="euiEmptyPrompt testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <svg
-    aria-hidden="true"
-    class="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
-    focusable="false"
-    height="16"
-    role="img"
-    viewBox="0 0 16 16"
-    width="16"
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    color="subdued"
+    data-euiicon-type="arrowUp"
   />
   <div
     class="euiSpacer euiSpacer--s"
@@ -105,15 +99,9 @@ exports[`EuiEmptyPrompt props iconType renders alone 1`] = `
 <div
   class="euiEmptyPrompt"
 >
-  <svg
-    aria-hidden="true"
-    class="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
-    focusable="false"
-    height="16"
-    role="img"
-    viewBox="0 0 16 16"
-    width="16"
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    color="subdued"
+    data-euiicon-type="arrowUp"
   />
   <div
     class="euiSpacer euiSpacer--s"

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -6,6 +6,10 @@ import cheerio from 'cheerio';
 import { EuiIcon, SIZES, TYPES, COLORS } from './icon';
 import { PropsOf } from '../common';
 
+jest.mock('./icon', () => {
+  return require.requireActual('./icon');
+});
+
 const prettyHtml = cheerio.load('');
 
 function testIcon(props: PropsOf<EuiIcon>) {


### PR DESCRIPTION
What do you think of this approach? Using `moduleNameMapper` to specify the mock appears to be more predictable (e.g. for some reason Jest didn't mock icon for `EuiEmptyPrompt`.)